### PR TITLE
FIX: queryparams not url encoded on Linux/Mac

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,9 +48,17 @@ kotlin {
         }
         val macosX64Main by getting {
             dependsOn(nativeCommonMain)
+            dependencies {
+                implementation("io.ktor:ktor-client-curl:1.5.1")
+                implementation("io.ktor:ktor-client-core:1.5.1")
+            }
         }
         val linuxX64Main by getting {
             dependsOn(nativeCommonMain)
+            dependencies {
+                implementation("io.ktor:ktor-client-curl:1.5.1")
+                implementation("io.ktor:ktor-client-core:1.5.1")
+            }
         }
 
         all {


### PR DESCRIPTION
Les query parameters n'était pas url encodé. Cela posait problème lors des appels "candidat/places" dans des villes avec des espaces dans leurs noms.
De plus j'ai rajouté le ktor client avec son moteur curl.