### PR TITLE
feat: add security headers inside http client

### DIFF
--- a/src/commonMain/kotlin/services/api/client/HttpClient.kt
+++ b/src/commonMain/kotlin/services/api/client/HttpClient.kt
@@ -1,5 +1,6 @@
 package services.api.client
 
+// TODO(arichard, 20/07/2022): add security headers inside http client
 internal expect class HttpClient {
     suspend inline fun <reified ExpectedResponse> get(
         endpoint: String,


### PR DESCRIPTION
Fixes #30 #27 #24 

- [ ] Linux
- [ ] MacOS
- [ ] Windows